### PR TITLE
Add support for rich text input

### DIFF
--- a/block.go
+++ b/block.go
@@ -40,6 +40,7 @@ type BlockAction struct {
 	Type                  ActionType          `json:"type"`
 	Text                  TextBlockObject     `json:"text"`
 	Value                 string              `json:"value"`
+	RichTextValue         RichTextBlock       `json:"rich_text_value"`
 	ActionTs              string              `json:"action_ts"`
 	SelectedOption        OptionBlockObject   `json:"selected_option"`
 	SelectedOptions       []OptionBlockObject `json:"selected_options"`

--- a/block_conv.go
+++ b/block_conv.go
@@ -116,6 +116,8 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 		e = &DatetimePickerBlockElement{}
 	case "plain_text_input":
 		e = &PlainTextInputBlockElement{}
+	case "rich_text_input":
+		e = &RichTextInputBlockElement{}
 	case "email_text_input":
 		e = &EmailInputBlockElement{}
 	case "url_text_input":
@@ -198,6 +200,8 @@ func (b *BlockElements) UnmarshalJSON(data []byte) error {
 			blockElement = &DatetimePickerBlockElement{}
 		case "plain_text_input":
 			blockElement = &PlainTextInputBlockElement{}
+		case "rich_text_input":
+			blockElement = &RichTextInputBlockElement{}
 		case "email_text_input":
 			blockElement = &EmailInputBlockElement{}
 		case "url_text_input":
@@ -300,6 +304,12 @@ func (a *Accessory) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		a.PlainTextInputElement = element.(*PlainTextInputBlockElement)
+	case "rich_text_input":
+		element, err := unmarshalBlockElement(r, &RichTextInputBlockElement{})
+		if err != nil {
+			return err
+		}
+		a.RichTextInputElement = element.(*RichTextInputBlockElement)
 	case "radio_buttons":
 		element, err := unmarshalBlockElement(r, &RadioButtonsBlockElement{})
 		if err != nil {

--- a/block_conv.go
+++ b/block_conv.go
@@ -66,6 +66,8 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &InputBlock{}
 		case "rich_text":
 			block = &RichTextBlock{}
+		case "rich_text_input":
+			block = &RichTextBlock{}
 		case "section":
 			block = &SectionBlock{}
 		case "call":

--- a/block_element.go
+++ b/block_element.go
@@ -15,6 +15,7 @@ const (
 	METEmailInput     MessageElementType = "email_text_input"
 	METNumberInput    MessageElementType = "number_input"
 	METURLInput       MessageElementType = "url_text_input"
+	METRichTextInput  MessageElementType = "rich_text_input"
 
 	MixedElementImage MixedElementType = "mixed_image"
 	MixedElementText  MixedElementType = "mixed_text"
@@ -51,6 +52,7 @@ type Accessory struct {
 	DatePickerElement          *DatePickerBlockElement
 	TimePickerElement          *TimePickerBlockElement
 	PlainTextInputElement      *PlainTextInputBlockElement
+	RichTextInputElement       *RichTextInputBlockElement
 	RadioButtonsElement        *RadioButtonsBlockElement
 	SelectElement              *SelectBlockElement
 	MultiSelectElement         *MultiSelectBlockElement
@@ -73,6 +75,8 @@ func NewAccessory(element BlockElement) *Accessory {
 		return &Accessory{TimePickerElement: element.(*TimePickerBlockElement)}
 	case *PlainTextInputBlockElement:
 		return &Accessory{PlainTextInputElement: element.(*PlainTextInputBlockElement)}
+	case *RichTextInputBlockElement:
+		return &Accessory{RichTextInputElement: element.(*RichTextInputBlockElement)}
 	case *RadioButtonsBlockElement:
 		return &Accessory{RadioButtonsElement: element.(*RadioButtonsBlockElement)}
 	case *SelectBlockElement:
@@ -470,9 +474,9 @@ func (s NumberInputBlockElement) ElementType() MessageElementType {
 // NewNumberInputBlockElement returns an instance of a number input.
 func NewNumberInputBlockElement(placeholder *TextBlockObject, actionID string, isDecimalAllowed bool) *NumberInputBlockElement {
 	return &NumberInputBlockElement{
-		Type:        METNumberInput,
-		ActionID:    actionID,
-		Placeholder: placeholder,
+		Type:             METNumberInput,
+		ActionID:         actionID,
+		Placeholder:      placeholder,
 		IsDecimalAllowed: isDecimalAllowed,
 	}
 }
@@ -507,6 +511,32 @@ func (s PlainTextInputBlockElement) ElementType() MessageElementType {
 func NewPlainTextInputBlockElement(placeholder *TextBlockObject, actionID string) *PlainTextInputBlockElement {
 	return &PlainTextInputBlockElement{
 		Type:        METPlainTextInput,
+		ActionID:    actionID,
+		Placeholder: placeholder,
+	}
+}
+
+// RichTextInputBlockElement creates a field where allows users to enter formatted text
+// in a WYSIWYG composer, offering the same messaging writing experience as in Slack
+// More Information: https://api.slack.com/reference/block-kit/block-elements#rich_text_input
+type RichTextInputBlockElement struct {
+	Type                 MessageElementType    `json:"type"`
+	ActionID             string                `json:"action_id,omitempty"`
+	Placeholder          *TextBlockObject      `json:"placeholder,omitempty"`
+	InitialValue         string                `json:"initial_value,omitempty"`
+	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
+	FocusOnLoad          bool                  `json:"focus_on_load,omitempty"`
+}
+
+// ElementType returns the type of the Element
+func (s RichTextInputBlockElement) ElementType() MessageElementType {
+	return s.Type
+}
+
+// NewRichTextInputBlockElement returns an instance of a rich-text input element
+func NewRichTextInputBlockElement(placeholder *TextBlockObject, actionID string) *RichTextInputBlockElement {
+	return &RichTextInputBlockElement{
+		Type:        METRichTextInput,
 		ActionID:    actionID,
 		Placeholder: placeholder,
 	}

--- a/block_element_test.go
+++ b/block_element_test.go
@@ -157,7 +157,12 @@ func TestNewEmailInputBlockElement(t *testing.T) {
 
 	assert.Equal(t, string(emailInputElement.Type), "email_text_input")
 	assert.Equal(t, emailInputElement.ActionID, "test")
+}
 
+func TestNewRichTextInputBlockElement(t *testing.T) {
+	richTextInputElement := NewRichTextInputBlockElement(nil, "test")
+	assert.Equal(t, string(richTextInputElement.Type), "rich_text_input")
+	assert.Equal(t, richTextInputElement.ActionID, "test")
 }
 
 func TestNewNumberInputBlockElement(t *testing.T) {


### PR DESCRIPTION
This builds on https://github.com/slack-go/slack/pull/1240 which adds support for the rich text input. On top of that is an update to the `BlockAction` struct to provide a field `RichTextValue` for the returned rich text to be deserialised in to.