### PR TITLE
Fix modelling of slack rich text

### DIFF
--- a/block_rich_text_test.go
+++ b/block_rich_text_test.go
@@ -80,7 +80,7 @@ func TestRichTextSection_UnmarshalJSON(t *testing.T) {
 		err      error
 	}{
 		{
-			[]byte(`{"elements":[{"type":"unknown","value":10},{"type":"text","text":"hi"},{"type":"date","timestamp":1636961629}]}`),
+			[]byte(`{"type": "rich_text_section", "elements":[{"type":"unknown","value":10},{"type":"text","text":"hi"},{"type":"date","timestamp":1636961629}]}`),
 			RichTextSection{
 				Type: RTESection,
 				Elements: []RichTextSectionElement{


### PR DESCRIPTION
`RichTextList` has elements that are `RichTextSection`s, not `RichTextSectionElement`.

Additionally:

- `RTEPreformatted` and `RTEQuote` weren't being marshalled/unmarshalled correctly, and we didn't have functions for creating them
- `NewRichTextSectionChannelElement` was setting the wrong type on the returned element