### PR TITLE
Fix InitialValue of RichTextInputBlockElement

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -523,7 +523,7 @@ type RichTextInputBlockElement struct {
 	Type                 MessageElementType    `json:"type"`
 	ActionID             string                `json:"action_id,omitempty"`
 	Placeholder          *TextBlockObject      `json:"placeholder,omitempty"`
-	InitialValue         string                `json:"initial_value,omitempty"`
+	InitialValue         RichTextBlock         `json:"initial_value,omitempty"`
 	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
 	FocusOnLoad          bool                  `json:"focus_on_load,omitempty"`
 }


### PR DESCRIPTION
It needs to be RichTextBlock so that we can pre-populate the input with rich text.

<img width="502" alt="Screenshot 2023-11-06 at 10 57 32" src="https://github.com/incident-io/slack/assets/640878/0c6fe037-2e7e-4029-8fbe-bb4c627cf5d6">
