### PR TITLE
Rich text initial value should be a pointer

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -523,7 +523,7 @@ type RichTextInputBlockElement struct {
 	Type                 MessageElementType    `json:"type"`
 	ActionID             string                `json:"action_id,omitempty"`
 	Placeholder          *TextBlockObject      `json:"placeholder,omitempty"`
-	InitialValue         RichTextBlock         `json:"initial_value,omitempty"`
+	InitialValue         *RichTextBlock        `json:"initial_value,omitempty"`
 	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
 	FocusOnLoad          bool                  `json:"focus_on_load,omitempty"`
 }


### PR DESCRIPTION
This means we can pass a null value and it'll be omitted
