### PR TITLE
Add ability to turn new enterprise grid IDs to old ones in migrationExchange

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -7,6 +7,7 @@ import (
 
 type migrationExchangeResponseFull struct {
 	TeamID         string            `json:"team_id"`
+	ToOld          bool              `json:"to_old"`
 	EnterpriseID   string            `json:"enterprise_id"`
 	UserIDMap      map[string]string `json:"user_id_map"`
 	InvalidUserIDs []string          `json:"invalid_user_ids"`
@@ -14,13 +15,17 @@ type migrationExchangeResponseFull struct {
 }
 
 // MigrationExchange for Enterprise Grid workspaces, map local user IDs to global user IDs
-func (api *Client) MigrationExchange(ctx context.Context, teamID string, users []string) (map[string]string, error) {
+func (api *Client) MigrationExchange(ctx context.Context, teamID string, toOld bool, users []string) (map[string]string, error) {
 	values := url.Values{
 		"users": users,
 	}
 	if teamID != "" {
 		values.Add("team_id", teamID)
 	}
+	if toOld {
+		values.Add("to_old", "true")
+	}
+
 	response := &migrationExchangeResponseFull{}
 	err := api.getMethod(ctx, "migration.exchange", api.token, values, response)
 	if err != nil {


### PR DESCRIPTION
https://api.slack.com/methods/migration.exchange#arg_to_old