### PR TITLE
Make RateLimitError implement error rather than making a pointer to i…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,4 +38,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # v3.2.0
         with:
-          version: v1.48.0
+          version: v1.49.0

--- a/misc.go
+++ b/misc.go
@@ -77,11 +77,11 @@ type RateLimitedError struct {
 	RetryAfter time.Duration
 }
 
-func (e *RateLimitedError) Error() string {
+func (e RateLimitedError) Error() string {
 	return fmt.Sprintf("slack rate limit exceeded, retry after %s", e.RetryAfter)
 }
 
-func (e *RateLimitedError) Retryable() bool {
+func (e RateLimitedError) Retryable() bool {
 	return true
 }
 

--- a/misc_test.go
+++ b/misc_test.go
@@ -107,8 +107,17 @@ func TestRetryable(t *testing.T) {
 }
 
 func TestCanUseErrorsAs(t *testing.T) {
-	_ = errors.As(errors.New("error"), &RateLimitedError{})
-	_ = errors.As(errors.New("error"), &StatusCodeError{})
-	_ = errors.As(errors.New("error"), &SlackError{})
+	ok := errors.As(RateLimitedError{}, &RateLimitedError{})
+	if !ok {
+		t.Errorf("cannot convert to RateLimitedError")
+	}
+	ok = errors.As(StatusCodeError{}, &StatusCodeError{})
+	if !ok {
+		t.Errorf("cannot convert to StatusCodeError")
+	}
+	ok = errors.As(SlackError{}, &SlackError{})
+	if !ok {
+		t.Errorf("cannot convert to SlackError")
+	}
 	// no panic means we're good
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net/http"
 	"net/url"
@@ -103,4 +104,11 @@ func TestRetryable(t *testing.T) {
 			t.Errorf("expected %#v to be Retryable", e)
 		}
 	}
+}
+
+func TestCanUseErrorsAs(t *testing.T) {
+	_ = errors.As(errors.New("error"), &RateLimitedError{})
+	_ = errors.As(errors.New("error"), &StatusCodeError{})
+	_ = errors.As(errors.New("error"), &SlackError{})
+	// no panic means we're good
 }


### PR DESCRIPTION
This changes the RateLimitedError so that it implements the error interface instead of *RateLimitedError. This is because errors.As expects "a pointer to something that implements the error interface" not "a pointer to something, that implements the error interface"