### PR TITLE
Don't marshal text property of links when it's empty

### DIFF
--- a/block_rich_text.go
+++ b/block_rich_text.go
@@ -364,7 +364,7 @@ func NewRichTextSectionEmojiElement(name string, skinTone int, style *RichTextSe
 type RichTextSectionLinkElement struct {
 	Type  RichTextSectionElementType `json:"type"`
 	URL   string                     `json:"url"`
-	Text  string                     `json:"text"`
+	Text  string                     `json:"text,omitempty"`
 	Style *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 


### PR DESCRIPTION
Slack returns an error if the text property is empty, but if it's not present everything is fine and it just uses the URL as the text of the link.