### PR TITLE
Remove duplicate profile change event

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -352,12 +352,6 @@ type TeamJoinEvent struct {
 	EventTimestamp string      `json:"event_ts"`
 }
 
-// UserProfileChangeEvent happens when a user's profile changes
-type UserProfileChangeEvent struct {
-	Type string      `json:"type"`
-	User *slack.User `json:"user"`
-}
-
 // TokensRevokedEvent APP's API tokens are revoked - https://api.slack.com/events/tokens_revoked
 type TokensRevokedEvent struct {
 	Type           string `json:"type"`


### PR DESCRIPTION
This isn't actually used anywhere, meaning that events are never parsed as this type. So having it is just a road to confusion and sadness.
