### PR TITLE
Support expand for section blocks

### DIFF
--- a/block_section.go
+++ b/block_section.go
@@ -9,6 +9,7 @@ type SectionBlock struct {
 	BlockID   string             `json:"block_id,omitempty"`
 	Fields    []*TextBlockObject `json:"fields,omitempty"`
 	Accessory *Accessory         `json:"accessory,omitempty"`
+	Expand    bool               `json:"expand,omitempty"`
 }
 
 // BlockType returns the type of the block
@@ -22,6 +23,15 @@ type SectionBlockOption func(*SectionBlock)
 func SectionBlockOptionBlockID(blockID string) SectionBlockOption {
 	return func(block *SectionBlock) {
 		block.BlockID = blockID
+	}
+}
+
+// SectionBlockOptionExpand allows long text to be auto-expanded when displaying
+//
+// @see https://api.slack.com/reference/block-kit/blocks#section
+func SectionBlockOptionExpand(shouldExpand bool) SectionBlockOption {
+	return func(block *SectionBlock) {
+		block.Expand = shouldExpand
 	}
 }
 

--- a/block_section_test.go
+++ b/block_section_test.go
@@ -34,3 +34,19 @@ func TestNewBlockSectionContainsAddedTextBlockAndAccessory(t *testing.T) {
 	assert.False(t, textBlockInSection.Verbatim)
 	assert.Equal(t, sectionBlock.Accessory.ImageElement, conflictImage)
 }
+
+func TestSectionBlockOptionExpand(t *testing.T) {
+	textInfo := NewTextBlockObject("mrkdwn", "This is a long text that should be auto-expanded", false, false)
+
+	// Create a section block with expand option set to true
+	sectionBlock := NewSectionBlock(textInfo, nil, nil, SectionBlockOptionExpand(true))
+
+	// Verify that the expand field is set correctly
+	assert.True(t, sectionBlock.Expand)
+
+	// Create another section block with expand option set to false
+	sectionBlock = NewSectionBlock(textInfo, nil, nil, SectionBlockOptionExpand(false))
+
+	// Verify that the expand field is set correctly
+	assert.False(t, sectionBlock.Expand)
+}


### PR DESCRIPTION
This allows auto-expanding section blocks in Slack where you may otherwise collapse them.