### PR TITLE
Update timezone unmarshaller

### DIFF
--- a/block.go
+++ b/block.go
@@ -55,6 +55,7 @@ type BlockAction struct {
 	SelectedDate          string              `json:"selected_date"`
 	SelectedTime          string              `json:"selected_time"`
 	SelectedDateTime      JSONTime            `json:"selected_date_time"`
+	Timezone              string              `json:"timezone"`
 	InitialOption         OptionBlockObject   `json:"initial_option"`
 	InitialUser           string              `json:"initial_user"`
 	InitialChannel        string              `json:"initial_channel"`

--- a/interactions_test.go
+++ b/interactions_test.go
@@ -140,7 +140,8 @@ const (
           "some_datetime": {
             "value": {
               "type": "datetimepicker",
-              "selected_date_time": null
+              "selected_date_time": null,
+							"timezone": "Europe/Berlin"
             }
           }
 				}
@@ -306,8 +307,9 @@ func TestViewSubmissionCallback(t *testing.T) {
 					},
 					"some_datetime": {
 						"value": BlockAction{
-							Type: "datetimepicker",
-							// No value!
+							Type:     "datetimepicker",
+							Timezone: "Europe/Berlin",
+							// No selected datetime!
 						},
 					},
 				},


### PR DESCRIPTION
A recent change added the ability to set a timezone field on the TimePickerBlockElement, however this also required changing the BlockAction unmarshaller, to detect any changes made to the timezone field.
